### PR TITLE
Generator.KeyFound event not passing value

### DIFF
--- a/mustache-sharp/KeyFoundEventArgs.cs
+++ b/mustache-sharp/KeyFoundEventArgs.cs
@@ -14,6 +14,7 @@ namespace Mustache
         internal KeyFoundEventArgs(string key, object value)
         {
             Key = key;
+            Substitute = value;
         }
 
         /// <summary>


### PR DESCRIPTION
KeyFoundEventArgs constructor didn't set the value leading to always
substituting with an empty string when using KeyFound event.
