### PR TITLE
Update FormatCompiler.cs

### DIFF
--- a/mustache-sharp/FormatCompiler.cs
+++ b/mustache-sharp/FormatCompiler.cs
@@ -143,7 +143,7 @@ namespace Mustache
                     matches.Add(getTagRegex(childDefinition));
                 }
                 matches.Add(getUnknownTagRegex());
-                string match = string.Format("{0}(" + String.Join("|", matches) + "){1}", _startTag, _endTag);
+                string match = _startTag + "(" + String.Join("|", matches) + ")" + _endTag;
                 regex = new Regex(match);
                 _regexLookup.Add(definition.Name, regex);
             }


### PR DESCRIPTION
added the possibility to change starting {{ and ending }} with optional constructor of Format Compiler

needed for using templating with Angular/handlerbar clientside
