### PR TITLE
Add support for escaped strings - closes #16

### DIFF
--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -1492,6 +1492,41 @@ Odd
 
         #endregion
 
+        #region Html Encoding
+        [TestMethod]
+        public void TestCompile_HtmlEncoder_EscapesHtmlInRegularKeyTags()
+        {
+            var compiler = new FormatCompiler(new HtmlEncoder());
+            const string format = @"Hello, {{this}}";
+            var generator = compiler.Compile(format);
+            const string expected = @"Hello, &lt;b&gt;Bob&lt;/b&gt;";
+            var actual = generator.Render("<b>Bob</b>");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestCompile_HtmlEncoder_DoesNotEscapeHtmlWithTripleMustache()
+        {
+            var compiler = new FormatCompiler(new HtmlEncoder());
+            const string format = @"Hello, {{{this}}}";
+            var generator = compiler.Compile(format);
+            const string expected = @"Hello, <b>Bob</b>";
+            var actual = generator.Render("<b>Bob</b>");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestCompile_HtmlEncoder_DoesNotEscapeHtmlWithAmprisand()
+        {
+            var compiler = new FormatCompiler(new HtmlEncoder());
+            const string format = @"Hello, {{&this}}";
+            var generator = compiler.Compile(format);
+            const string expected = @"Hello, <b>Bob</b>";
+            var actual = generator.Render("<b>Bob</b>");
+            Assert.AreEqual(expected, actual);
+        }
+        #endregion
+
         #region Strings
 
         /// <summary>

--- a/mustache-sharp/HtmlEncoder.cs
+++ b/mustache-sharp/HtmlEncoder.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using System.Web;
+
+namespace Mustache
+{
+    public class HtmlEncoder : IStringEncoder
+    {
+        public void WriteEncoded(string input, TextWriter textWriter)
+        {
+            HttpUtility.HtmlEncode(input, textWriter);
+        }
+    }
+}

--- a/mustache-sharp/IStringEncoder.cs
+++ b/mustache-sharp/IStringEncoder.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace Mustache
+{
+    public interface IStringEncoder
+    {
+        void WriteEncoded(string input, TextWriter textWriter);
+    }
+}

--- a/mustache-sharp/KeyGenerator.cs
+++ b/mustache-sharp/KeyGenerator.cs
@@ -9,6 +9,7 @@ namespace Mustache
     /// </summary>
     internal sealed class KeyGenerator : IGenerator
     {
+        private readonly IStringEncoder _encoder;
         private readonly string _key;
         private readonly string _format;
         private readonly bool _isVariable;
@@ -19,8 +20,10 @@ namespace Mustache
         /// <param name="key">The key to substitute with its value.</param>
         /// <param name="alignment">The alignment specifier.</param>
         /// <param name="formatting">The format specifier.</param>
-        public KeyGenerator(string key, string alignment, string formatting)
+        /// <param name="encoder">The encoder (i.e. HTML to escape the resulting string)</param>
+        public KeyGenerator(string key, string alignment, string formatting, IStringEncoder encoder)
         {
+            _encoder = encoder;
             if (key.StartsWith("@"))
             {
                 _key = key.Substring(1);
@@ -36,7 +39,7 @@ namespace Mustache
 
         private static string getFormat(string alignment, string formatting)
         {
-            StringBuilder formatBuilder = new StringBuilder();
+            var formatBuilder = new StringBuilder();
             formatBuilder.Append("{0");
             if (!String.IsNullOrWhiteSpace(alignment))
             {
@@ -55,7 +58,7 @@ namespace Mustache
         void IGenerator.GetText(Scope scope, TextWriter writer, Scope context)
         {
             object value = _isVariable ? context.Find(_key) : scope.Find(_key);
-            writer.Write(_format, value);
+            _encoder.WriteEncoded(string.Format(_format, value), writer);
         }
     }
 }

--- a/mustache-sharp/LiteralKeyGenerator.cs
+++ b/mustache-sharp/LiteralKeyGenerator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+
+namespace Mustache
+{
+    /// <summary>
+    /// Substitutes a key placeholder with the textual representation of the
+    /// associated object without escaping the output.
+    /// </summary>
+    internal sealed class LiteralKeyGenerator : IGenerator
+    {
+        private readonly string _key;
+        private readonly bool _isVariable;
+
+        /// <summary>
+        /// Initializes a new instance of a LiteralKeyGenerator.
+        /// </summary>
+        /// <param name="key">The key to substitute with its value.</param>
+        public LiteralKeyGenerator(string key)
+        {
+            if (key.StartsWith("@"))
+            {
+                _key = key.Substring(1);
+                _isVariable = true;
+            }
+            else
+            {
+                _key = key;
+                _isVariable = false;
+            }
+        }
+
+        void IGenerator.GetText(Scope scope, TextWriter writer, Scope context)
+        {
+            object value = _isVariable ? context.Find(_key) : scope.Find(_key);
+            writer.Write(value);
+        }
+    }
+}

--- a/mustache-sharp/PlainTextEncoder.cs
+++ b/mustache-sharp/PlainTextEncoder.cs
@@ -1,0 +1,12 @@
+﻿using System.IO;
+
+namespace Mustache
+{
+    public class PlainTextEncoder : IStringEncoder
+    {
+        public void WriteEncoded(string input, TextWriter textWriter)
+        {
+            textWriter.Write(input);
+        }
+    }
+}

--- a/mustache-sharp/mustache-sharp.csproj
+++ b/mustache-sharp/mustache-sharp.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentCollection.cs" />
@@ -40,7 +41,11 @@
     <Compile Include="ContentTagDefinition.cs" />
     <Compile Include="Context.cs" />
     <Compile Include="ContextParameter.cs" />
+    <Compile Include="HtmlEncoder.cs" />
+    <Compile Include="PlainTextEncoder.cs" />
+    <Compile Include="LiteralKeyGenerator.cs" />
     <Compile Include="IArgument.cs" />
+    <Compile Include="IStringEncoder.cs" />
     <Compile Include="NumberArgument.cs" />
     <Compile Include="PlaceholderArgument.cs" />
     <Compile Include="StringArgument.cs" />


### PR DESCRIPTION
This is in line with standard mustache/handlebars. Double-mustache tags will be encoded with the provided IStringEncoder (defaults to PlainTextEncoder), while triple-mustache tags will be left as-is. This should be 100% backwards-compatible and passes all existing unit tests without modification.

Using HTML encoding looks like this, as defined in the test cases:

``` csharp
var compiler = new FormatCompiler(new HtmlEncoder());
const string format = @"Hello, {{this}}";
var generator = compiler.Compile(format);
const string expected = @"Hello, &lt;b&gt;Bob&lt;/b&gt;";
var actual = generator.Render("<b>Bob</b>");
Assert.AreEqual(expected, actual);
```

Literal tagging looks like this:

``` csharp
var compiler = new FormatCompiler(new HtmlEncoder());
const string format = @"Hello, {{{this}}}";
var generator = compiler.Compile(format);
const string expected = @"Hello, <b>Bob</b>";
var actual = generator.Render("<b>Bob</b>");
Assert.AreEqual(expected, actual);
```
