### PR TITLE
Specify a CultureInfo on TestCompile_MultipleTags

### DIFF
--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -1363,7 +1363,7 @@ Your order total was: {{Total:C}}
 {{/if}}
 {{/with}}";
             Generator generator = compiler.Compile(format);
-            string result = generator.Render(new
+            string result = generator.Render(new System.Globalization.CultureInfo("en-US"), new
             {
                 Customer = new { FirstName = "Bob" },
                 Order = new


### PR DESCRIPTION
TestCompile_MultipleTags will fail if CultureInfo.CurrentCulture is not en-US.

output example (in ja-JP):

```
Hello Bob:



Below are your order details:



    Banana: ¥3 x 1

    Orange: ¥1 x 5

    Apple: ¥0 x 10



Your order total was: ¥8
```
