### PR TITLE
Support for access array elements + bug fixes

### DIFF
--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -529,6 +529,27 @@ Content";
             public new T Value { get; set; }
         }
 
+		/// <summary>
+		/// Access array elements and this
+		/// </summary>
+		[TestMethod]
+		public void TestCompile_Access_Arrays_And_This() {
+			FormatCompiler compiler = new FormatCompiler();
+			const string format = @"Hello, {{Array.[0]}} {{O.[1]}} {{O.[Good evening]}}!!!";
+			Generator generator = compiler.Compile(format);
+			string result = generator.Render(new { O = new ThisAccessor(), Array = new string[] { "Element 0", "Element 1" } });
+			Assert.AreEqual("Hello, Element 0 1 Good evening!!!", result, "The wrong text was generated.");
+		}
+
+		public class ThisAccessor {
+			public string this[int i] {
+				get { return i.ToString(); }
+			}
+
+			public string this[string s] {
+				get { return s; }
+			}
+		}
         #endregion
 
         #region Comment

--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1363,7 +1364,7 @@ Your order total was: {{Total:C}}
 {{/if}}
 {{/with}}";
             Generator generator = compiler.Compile(format);
-            string result = generator.Render(new
+            string result = generator.Render(new CultureInfo("en-US"), new
             {
                 Customer = new { FirstName = "Bob" },
                 Order = new

--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -541,6 +541,16 @@ Content";
 			Assert.AreEqual("Hello, Element 0 1 Good evening!!!", result, "The wrong text was generated.");
 		}
 
+        [TestMethod]
+        public void TestCompile_Access_Arrays_And_This_With_One_Element()
+        {
+            FormatCompiler compiler = new FormatCompiler();
+            const string format = @"Hello, {{Array.[0]}}!!!";
+            Generator generator = compiler.Compile(format);
+            string result = generator.Render(new { Array = new string[] { "Element 0"} });
+            Assert.AreEqual("Hello, Element 0!!!", result, "The wrong text was generated.");
+        }
+
 		public class ThisAccessor {
 			public string this[int i] {
 				get { return i.ToString(); }

--- a/mustache-sharp/FormatCompiler.cs
+++ b/mustache-sharp/FormatCompiler.cs
@@ -152,7 +152,7 @@ namespace Mustache
 
         private static string getKeyRegex()
         {
-            return @"((?<key>" + RegexHelper.CompoundKey + @")(,(?<alignment>(\+|-)?[\d]+))?(:(?<format>.*?))?)";
+            return @"((?<key>@?" + RegexHelper.CompoundKeyOrArrayAccess + @")(,(?<alignment>(\+|-)?[\d]+))?(:(?<format>.*?))?)";
         }
 
         private static string getTagRegex(TagDefinition definition)
@@ -164,7 +164,7 @@ namespace Mustache
             foreach (TagParameter parameter in definition.Parameters)
             {
                 regexBuilder.Append(@"(\s+?");
-                regexBuilder.Append(@"(?<argument>(");
+                regexBuilder.Append(@"(?<argument>(@?");
                 regexBuilder.Append(RegexHelper.Argument);
                 regexBuilder.Append(@")))");
                 if (!parameter.IsRequired)

--- a/mustache-sharp/Properties/AssemblyInfo.cs
+++ b/mustache-sharp/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 [assembly: Guid("e5a4263d-d450-4d85-a4d5-44c0a2822668")]
-[assembly: AssemblyVersion("0.2.8.1")]
-[assembly: AssemblyFileVersion("0.2.8.1")]
+[assembly: AssemblyVersion("0.2.8.2")]
+[assembly: AssemblyFileVersion("0.2.8.2")]
 [assembly: InternalsVisibleTo("mustache-sharp.test")]

--- a/mustache-sharp/PropertyDictionary.cs
+++ b/mustache-sharp/PropertyDictionary.cs
@@ -16,6 +16,8 @@ namespace Mustache
 
         private readonly object _instance;
         private readonly Dictionary<string, Func<object, object>> _typeCache;
+		private PropertyInfo _intThis;
+		private PropertyInfo _stringThis;
 
         /// <summary>
         /// Initializes a new instance of a PropertyDictionary.
@@ -30,10 +32,9 @@ namespace Mustache
             }
             else
             {
-                lock (_cache)
-                {
-                    _typeCache = getCacheType(_instance);
-                }
+                _typeCache = getCacheType(_instance);
+				_intThis = _instance.GetType().GetProperty("Item", new Type[] { typeof(int) });
+				_stringThis = _instance.GetType().GetProperty("Item", new Type[] { typeof(string) });
             }
         }
 
@@ -119,6 +120,10 @@ namespace Mustache
             return _typeCache.ContainsKey(key);
         }
 
+		public bool HasIntThis { get { return _intThis != null; } }
+
+		public bool HasStringThis { get { return _stringThis != null; } }
+
         /// <summary>
         /// Gets the name of the properties in the type.
         /// </summary>
@@ -152,7 +157,43 @@ namespace Mustache
             return true;
         }
 
-        /// <summary>
+ 		/// <summary>
+		/// Tries to get the this[key] value for the given property name.
+		/// </summary>
+		/// <param name="key">The index to use in the this method.</param>
+		/// <param name="value">The variable to store the value of the property or the default value if the property is not found.</param>
+		/// <returns>True if a result was found; false if an exception was thrown.</returns>
+		/// <exception cref="System.ArgumentNullException">The key was null.</exception>
+
+		public bool TryGetThisValue(int key, out object value) {
+			try {
+				value = _intThis.GetValue(_instance, new object[] { key });
+				return true;
+			} catch {
+				value = null;
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Tries to get the this[key] value for the given property name.
+		/// </summary>
+		/// <param name="key">The index to use in the this method.</param>
+		/// <param name="value">The variable to store the value of the property or the default value if the property is not found.</param>
+		/// <returns>True if a result was found; false if an exception was thrown.</returns>
+		/// <exception cref="System.ArgumentNullException">The key was null.</exception>
+
+		public bool TryGetThisValue(string key, out object value) {
+			try {
+				value = _stringThis.GetValue(_instance, new object[] { key });
+				return true;
+			} catch {
+				value = null;
+				return false;
+			}
+		}
+
+       /// <summary>
         /// Gets the values of all of the properties in the object.
         /// </summary>
         public ICollection<object> Values

--- a/mustache-sharp/RegexHelper.cs
+++ b/mustache-sharp/RegexHelper.cs
@@ -12,7 +12,13 @@ namespace Mustache
         public const string String = @"'.*?'";
         public const string Number = @"[-+]?\d*\.?\d+";
         public const string CompoundKey = "@?" + Key + @"(?:\." + Key + ")*";
-        public const string Argument = @"(?:(?<arg_key>" + CompoundKey + @")|(?<arg_string>" + String + @")|(?<arg_number>" + Number + @"))";
+        public const string Argument = @"(?:(?<arg_key>" + CompoundKeyOrArrayAccess + @")|(?<arg_string>" + String + @")|(?<arg_number>" + Number + @"))";
+		public const string KeyOrArrayAccess = "(?:" + Key + @"|\[[^\]]+\]" + ")";
+		public const string CompoundKeyOrArrayAccess = KeyOrArrayAccess + @"(\." + KeyOrArrayAccess + ")*";
+
+		public static bool IsInteger(string s) {
+			return Regex.IsMatch(s, @"^\d{1,10}$");
+		}
 
         /// <summary>
         /// Determines whether the given name is a legal identifier.
@@ -48,5 +54,15 @@ namespace Mustache
             Regex regex = new Regex("^" + Number + "$");
             return regex.IsMatch(value);
         }
+
+		public static string[] SplitKey(string compoundKey) {
+			MatchCollection m = Regex.Matches(compoundKey, KeyOrArrayAccess);
+			// Would prefer to use Linq for this, but MatchCollection does not seem to support it
+			string[] result = new string[m.Count];
+			for (int i = 0; i < result.Length; i++) {
+				result[i] = m[i].Value;
+			}
+			return result;
+		}
     }
 }

--- a/mustache-sharp/Scope.cs
+++ b/mustache-sharp/Scope.cs
@@ -237,7 +237,7 @@ namespace Mustache
 						if (dic.TryGetThisValue(i, out value)) return true;
 					}
 					Array array = dic.Instance as Array;
-					if (array != null && i < array.GetUpperBound(0)) {
+					if (array != null && i <= array.GetUpperBound(0)) {
 						value = array.GetValue(i);
 						return true;
 					}

--- a/mustache-sharp/Scope.cs
+++ b/mustache-sharp/Scope.cs
@@ -182,7 +182,7 @@ namespace Mustache
         private SearchResults tryFind(string name)
         {
             SearchResults results = new SearchResults();
-            results.Members = name.Split('.');
+            results.Members = RegexHelper.SplitKey(name);
             results.MemberIndex = 0;
             if (results.Member == "this")
             {
@@ -199,7 +199,7 @@ namespace Mustache
                 results.Lookup = toLookup(results.Value);
                 results.MemberIndex = index;
                 object value;
-                results.Found = results.Lookup.TryGetValue(results.Member, out value);
+                results.Found = tryLookup(results, out value);
                 results.Value = value;
             }
             return results;
@@ -209,7 +209,7 @@ namespace Mustache
         {
             results.Lookup = toLookup(_source);
             object value;
-            if (results.Lookup.TryGetValue(results.Member, out value))
+            if (tryLookup(results, out value))
             {
                 results.Found = true;
                 results.Value = value;
@@ -223,6 +223,31 @@ namespace Mustache
             }
             _parent.tryFindFirst(results);
         }
+
+		private bool tryLookup(SearchResults results, out object value) {
+			string member = results.Member;
+			if (member.StartsWith("[")) {
+				value = null;
+				PropertyDictionary dic = results.Lookup as PropertyDictionary;
+				if (dic == null) return false;
+				member = member.Substring(1, member.Length - 2);
+				if (RegexHelper.IsInteger(member)) {
+					int i = int.Parse(member);
+					if (dic.HasIntThis) {
+						if (dic.TryGetThisValue(i, out value)) return true;
+					}
+					Array array = dic.Instance as Array;
+					if (array != null && i < array.GetUpperBound(0)) {
+						value = array.GetValue(i);
+						return true;
+					}
+				}
+				if(dic.HasStringThis) return (dic.TryGetThisValue(member, out value));
+				return false;
+			} else {
+				return results.Lookup.TryGetValue(member, out value);
+			}
+		}
     }
 
     internal class SearchResults


### PR DESCRIPTION
Contains the access array elements support from nikkelocke fork as well some minor bugfixes:
* 'en-us' cultureinfo added in the 'TestCompile_MultipleTags' test
* a bug fix to the array element access (support for an array containing one element)

Would love to know the status of the project.  Do you intend to continue your development?  Need help?

Drop me a line :-)

**Thanks!**