### PR TITLE
Start and End Tags (For use with Each Tag)

### DIFF
--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -1243,6 +1243,20 @@ Last";
         }
 
         /// <summary>
+        /// We can use the start and end tags to get a bool if iteration is at the start of the collection or end.
+        /// </summary>
+        [TestMethod]
+        public void TestCompile_Each_StartEnd_PrintsStartEndOfCollection()
+        {
+            FormatCompiler parser = new FormatCompiler();
+            const string format = "{{#each this}}{{#start}}{{#end}}{{/each}}";
+            Generator generator = parser.Compile(format);
+            string result = generator.Render(new int[] { 1, 2, 3 });
+            const string expected = @"TrueFalseFalseFalseFalseTrue";
+            Assert.AreEqual(expected, result, "The wrong text was generated.");
+        }
+
+        /// <summary>
         /// A bug was found where the index tag was trying to read the arguments for the next tag.
         /// This was caused by the index tag chewing up more of the input than it was supposed to.
         /// </summary>
@@ -1421,6 +1435,20 @@ Your order total was: $7.50";
             string actual = generator.Render(new int[] { 1, 1, 1, 1, });
             string expected = "123";
             Assert.AreEqual(expected, actual, "The numbers were not valid.");
+        }
+
+        /// <summary>
+        /// We will use the start and end variables to determine what to print.
+        /// </summary>
+        [TestMethod]
+        public void TestCompile_CanUseContextStartEndVariablesToMakeDecisions()
+        {
+            FormatCompiler compiler = new FormatCompiler();
+            const string format = @"{{#each this}}{{#if @start}}<li class=""first""></li>{{#elif @end}}<li class=""last""></li>{{#else}}<li class=""middle""></li>{{/if}}{{/each}}";
+            Generator generator = compiler.Compile(format);
+            string actual = generator.Render(new int[] { 1, 1, 1, 1, });
+            string expected = @"<li class=""first""></li><li class=""middle""></li><li class=""middle""></li><li class=""last""></li>";
+            Assert.AreEqual(expected, actual, "The string is not valid.");
         }
 
         /// <summary>

--- a/mustache-sharp/EachTagDefinition.cs
+++ b/mustache-sharp/EachTagDefinition.cs
@@ -58,6 +58,14 @@ namespace Mustache
             {
                 yield break;
             }
+
+            int count = 0;
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                count++;
+            }
+
             int index = 0;
             foreach (object item in enumerable)
             {
@@ -68,6 +76,8 @@ namespace Mustache
                     ContextScope = contextScope.CreateChildScope(),
                 };
                 childContext.ContextScope.Set("index", index);
+                childContext.ContextScope.Set("start", index == 0);
+                childContext.ContextScope.Set("end", (index + 1) == count);
                 yield return childContext;
                 ++index;
             }
@@ -79,7 +89,7 @@ namespace Mustache
         /// <returns>The name of the tags that are in scope.</returns>
         protected override IEnumerable<string> GetChildTags()
         {
-            return new string[] { "index" };
+            return new string[] { "index", "start", "end" };
         }
 
         /// <summary>

--- a/mustache-sharp/EndTagDefinition.cs
+++ b/mustache-sharp/EndTagDefinition.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mustache
+{
+    /// <summary>
+    /// Defines a tag that outputs a bool of the end within an each loop.
+    /// </summary>
+    internal sealed class EndTagDefinition : InlineTagDefinition
+    {
+        /// <summary>
+        /// Initializes a new instance of an EndTagDefinition.
+        /// </summary>
+        public EndTagDefinition()
+            : base("end", true)
+        {
+        }
+
+        /// <summary>
+        /// Gets the text to output.
+        /// </summary>
+        /// <param name="writer">The writer to write the output to.</param>
+        /// <param name="arguments">The arguments passed to the tag.</param>
+        /// <param name="contextScope">Extra data passed along with the context.</param>
+        public override void GetText(TextWriter writer, Dictionary<string, object> arguments, Scope contextScope)
+        {
+            object index;
+            if (contextScope.TryFind("end", out index))
+            {
+                writer.Write(index);
+            }
+        }
+    }
+}

--- a/mustache-sharp/FormatCompiler.cs
+++ b/mustache-sharp/FormatCompiler.cs
@@ -35,6 +35,10 @@ namespace Mustache
             _tagLookup.Add(eachDefinition.Name, eachDefinition);
             IndexTagDefinition indexDefinition = new IndexTagDefinition();
             _tagLookup.Add(indexDefinition.Name, indexDefinition);
+            StartTagDefinition startDefinition = new StartTagDefinition();
+            _tagLookup.Add(startDefinition.Name, startDefinition);
+            EndTagDefinition endDefinition = new EndTagDefinition();
+            _tagLookup.Add(endDefinition.Name, endDefinition);
             WithTagDefinition withDefinition = new WithTagDefinition();
             _tagLookup.Add(withDefinition.Name, withDefinition);
             NewlineTagDefinition newlineDefinition = new NewlineTagDefinition();

--- a/mustache-sharp/StartTagDefinition.cs
+++ b/mustache-sharp/StartTagDefinition.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mustache
+{
+    /// <summary>
+    /// Defines a tag that outputs a bool of the start within an each loop.
+    /// </summary>
+    internal sealed class StartTagDefinition : InlineTagDefinition
+    {
+        /// <summary>
+        /// Initializes a new instance of an StartTagDefinition.
+        /// </summary>
+        public StartTagDefinition()
+            : base("start", true)
+        {
+        }
+
+        /// <summary>
+        /// Gets the text to output.
+        /// </summary>
+        /// <param name="writer">The writer to write the output to.</param>
+        /// <param name="arguments">The arguments passed to the tag.</param>
+        /// <param name="contextScope">Extra data passed along with the context.</param>
+        public override void GetText(TextWriter writer, Dictionary<string, object> arguments, Scope contextScope)
+        {
+            object index;
+            if (contextScope.TryFind("start", out index))
+            {
+                writer.Write(index);
+            }
+        }
+    }
+}

--- a/mustache-sharp/mustache-sharp.csproj
+++ b/mustache-sharp/mustache-sharp.csproj
@@ -46,6 +46,8 @@
     <Compile Include="ContentTagDefinition.cs" />
     <Compile Include="Context.cs" />
     <Compile Include="ContextParameter.cs" />
+    <Compile Include="EndTagDefinition.cs" />
+    <Compile Include="StartTagDefinition.cs" />
     <Compile Include="Substitution.cs" />
     <Compile Include="TagFormattedEventArgs.cs" />
     <Compile Include="HtmlFormatCompiler.cs" />


### PR DESCRIPTION
I updated the each tag to set the context of the bool values start and end. When the collection starts the loop, start will be true, then false as it continues. End will be false until the collection length has been reached.

I know that you can tell if the collection has started iterating based on if the index is 0, however I could not find a way to tell if each tag had finished iterating.

I believe this is useful for html templating if you'd like to format html different based on start, middle, and end of a collection.

For example in a menu:

```
<li class="first">Menu Item 1</li>
<li>Menu Item 2</li>
<li>Menu Item 3</li>
<li class="last">Menu Item 4</li>
```