### PR TITLE
Enable dynamic json object as source

### DIFF
--- a/mustache-sharp.test/JsonTests.cs
+++ b/mustache-sharp.test/JsonTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Mustache.Test
+{
+    [TestClass]
+    public class JsonIfTests
+    {
+        private void AssertJsonReturnsExpected(string json, string expected)
+        {
+            var compiler = new HtmlFormatCompiler();
+            const string format = @"Hello{{#if ifTrue}}, {{name}}{{/if}}!!!";
+
+            var generator = compiler.Compile(format);
+            dynamic jsonObject = JsonConvert.DeserializeObject<dynamic>(json);
+            string actual = generator.Render(jsonObject);
+            Assert.AreEqual(expected, actual, "The wrong message was generated.");
+        }
+
+        [TestMethod]
+        public void NonEmptyArrayShows()
+        {
+            string json = "{'name': 'FirstName', ifTrue: [1]}";
+            string expected = "Hello, FirstName!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void EmptyArrayHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: []}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void ZeroIntegerHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: 0}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void NonZeroIntegerShows()
+        {
+            string json = "{'name': 'FirstName', ifTrue: 1}";
+            string expected = "Hello, FirstName!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void ZeroFloatHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: 0.0}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void NonZeroFloatShows()
+        {
+            string json = "{'name': 'FirstName', ifTrue: 99.0}";
+            string expected = "Hello, FirstName!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void NullHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: null}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void FalseHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: false}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void TrueShows()
+        {
+            string json = "{'name': 'FirstName', ifTrue: true}";
+            string expected = "Hello, FirstName!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+        [TestMethod]
+        public void EmptyStringHides()
+        {
+            string json = "{'name': 'FirstName', ifTrue: ''}";
+            string expected = "Hello!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+
+        [TestMethod]
+        public void NonEmptyStringShows()
+        {
+            string json = "{'name': 'FirstName', ifTrue: 'asdf'}";
+            string expected = "Hello, FirstName!!!";
+            AssertJsonReturnsExpected(json, expected);
+        }
+    }
+}

--- a/mustache-sharp.test/mustache-sharp.test.csproj
+++ b/mustache-sharp.test/mustache-sharp.test.csproj
@@ -40,7 +40,12 @@
     <AssemblyOriginatorKeyFile>mustache-sharp.test.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>
@@ -52,6 +57,7 @@
   <ItemGroup>
     <Compile Include="FormatCompilerTester.cs" />
     <Compile Include="HtmlFormatCompilerTester.cs" />
+    <Compile Include="JsonTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UpcastDictionaryTester.cs" />
   </ItemGroup>
@@ -63,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="mustache-sharp.test.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/mustache-sharp.test/packages.config
+++ b/mustache-sharp.test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
+</packages>

--- a/mustache-sharp/ConditionTagDefinition.cs
+++ b/mustache-sharp/ConditionTagDefinition.cs
@@ -69,6 +69,33 @@ namespace Mustache
             {
                 return false;
             }
+
+            var conditionType = condition.GetType();
+            switch(conditionType.FullName)
+            { 
+                case "Newtonsoft.Json.Linq.JValue":
+                    dynamic dynamicCondition = condition;
+                    string jvalueType = dynamicCondition.Type.ToString();
+
+                    switch (jvalueType)
+                    {
+                        case "String":
+                            return !string.IsNullOrWhiteSpace(dynamicCondition.Value);
+                        case "Boolean":
+                            return dynamicCondition.Value;
+                        case "Integer":
+                        case "Float": //CLR type == double
+                            return dynamicCondition.Value != 0;
+                        case "Null":
+                            return false;
+                        default:
+                            throw new Exception($"Unsupported JValue type: '{jvalueType}'");
+                    }
+                case "Newtonsoft.Json.Linq.JArray":
+                    dynamic jsonArray = condition;
+                    return jsonArray.Count > 0;
+            }
+
             IEnumerable enumerable = condition as IEnumerable;
             if (enumerable != null)
             {

--- a/mustache-sharp/mustache-sharp.csproj
+++ b/mustache-sharp/mustache-sharp.csproj
@@ -37,6 +37,7 @@
     <AssemblyOriginatorKeyFile>mustache-sharp.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I've found this library enormously useful and am currently using it from PowerShell to template some emails.  I am able to marshal data between PowerShell and C# using json, but unfortunately the if-condition doesn't work with dynamic Newtonsoft.Json types.

I've added support for Newtonsoft.Json to the ConditionTagDefinition class using the dynamic keyword to avoid adding a dependency to the main assembly.

These changes allow the following (see JsonIfTests.cs for more possibilities):
   ```csharp
   string json = "{'name': 'FirstName', ifTrue: 1}";
   string expected = "Hello, FirstName!!!";
   const string format = @"Hello{{#if ifTrue}}, {{name}}{{/if}}!!!";
   
   var compiler = new HtmlFormatCompiler();
   var generator = compiler.Compile(format);
   dynamic jsonObject = JsonConvert.DeserializeObject<dynamic>(json);
   string actual = generator.Render(jsonObject);
   Assert.AreEqual(expected, actual, "The wrong message was generated.");