### PR TITLE
Created a Delimiter tag that allows nicely delimited lists

### DIFF
--- a/mustache-sharp.test/FormatCompilerTester.cs
+++ b/mustache-sharp.test/FormatCompilerTester.cs
@@ -209,7 +209,7 @@ namespace Mustache.Test
         }
 
         /// <summary>
-        /// If we specify a positive alignment with a key with an optional + character, 
+        /// If we specify a positive alignment with a key with an optional + character,
         /// the alignment should be used when rending the value.
         /// </summary>
         [TestMethod]
@@ -1285,6 +1285,37 @@ Item Number: foo<br />
 
         #endregion
 
+        #region Delimiter
+
+        /// <summary>
+        /// If we pass an empty collection to an each statement, the content should not be printed.
+        /// </summary>
+        [TestMethod]
+        public void TestCompile_Delimiter_EmptyCollection_SkipsContent()
+        {
+            FormatCompiler parser = new FormatCompiler();
+            const string format = "Before{{#each this}}{{this}}{{#delimiter}},{{/delimiter}}{{/each}}After";
+            Generator generator = parser.Compile(format);
+            string result = generator.Render(new int[0]);
+            Assert.AreEqual("BeforeAfter", result, "The wrong text was generated.");
+        }
+
+        /// <summary>
+        /// If we pass a populated collection to an each statement, the content should be printed
+        /// for each item in the collection, using that item as the new scope context.
+        /// </summary>
+        [TestMethod]
+        public void TestCompile_Delimiter_PopulatedCollection_PrintsContentForEachExceptLast()
+        {
+            FormatCompiler parser = new FormatCompiler();
+            const string format = "Before{{#each this}}{{this}}{{#delimiter}},{{/delimiter}}{{/each}}After";
+            Generator generator = parser.Compile(format);
+            string result = generator.Render(new int[] { 1, 2, 3 });
+            Assert.AreEqual("Before1,2,3After", result, "The wrong text was generated.");
+        }
+
+        #endregion
+
         #region With
 
         /// <summary>
@@ -1305,7 +1336,7 @@ Item Number: foo<br />
         #region Default Parameter
 
         /// <summary>
-        /// If a tag is defined with a default parameter, the default value 
+        /// If a tag is defined with a default parameter, the default value
         /// should be returned if an argument is not provided.
         /// </summary>
         [TestMethod]
@@ -1370,7 +1401,7 @@ Your order total was: {{Total:C}}
                 Order = new
                 {
                     Total = 7.50m,
-                    LineItems = new object[] 
+                    LineItems = new object[]
                     {
                         new { Name = "Banana", UnitPrice = 2.50m, Quantity = 1 },
                         new { Name = "Orange", UnitPrice = .50m, Quantity = 5 },
@@ -1477,7 +1508,7 @@ Odd
         /// they should not be removed from the output.
 		/// </summary>
 		[TestMethod]
-		public void TestCompile_PreserveNewLines() 
+		public void TestCompile_PreserveNewLines()
         {
 		    FormatCompiler compiler = new FormatCompiler();
 		    compiler.RemoveNewLines = false;

--- a/mustache-sharp/DelimiterTagDefinition.cs
+++ b/mustache-sharp/DelimiterTagDefinition.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Mustache
+{
+    internal sealed class DelimiterTagDefinition : ContentTagDefinition
+    {
+        /// <summary>
+        /// Initializes a new instance of an DelimiterTagDefinition.
+        /// </summary>
+        public DelimiterTagDefinition()
+            : base("delimiter", true)
+        {
+        }
+
+        /// <summary>
+        /// Gets the parameters that are used to create a new child context.
+        /// </summary>
+        /// <returns>The parameters that are used to create a new child context.</returns>
+        public override IEnumerable<TagParameter> GetChildContextParameters()
+        {
+            return new TagParameter[0];
+        }
+
+        /// <summary>
+        /// Gets the context to use when building the inner text of the tag.
+        /// </summary>
+        /// <param name="writer">The text writer passed</param>
+        /// <param name="keyScope">The current key scope.</param>
+        /// <param name="arguments">The arguments passed to the tag.</param>
+        /// <returns>The scope to use when building the inner text of the tag.</returns>
+        public override IEnumerable<NestedContext> GetChildContext(
+            TextWriter writer,
+            Scope keyScope,
+            Dictionary<string, object> arguments,
+            Scope contextScope)
+        {
+            if (!(bool) contextScope.Find("isDelimited", false))
+                yield break;
+
+            foreach(var childContext in base.GetChildContext(writer, keyScope, arguments, contextScope))
+            {
+                yield return childContext;
+            }
+        }
+    }
+}

--- a/mustache-sharp/EachTagDefinition.cs
+++ b/mustache-sharp/EachTagDefinition.cs
@@ -47,8 +47,8 @@ namespace Mustache
         /// <param name="arguments">The arguments passed to the tag.</param>
         /// <returns>The scope to use when building the inner text of the tag.</returns>
         public override IEnumerable<NestedContext> GetChildContext(
-            TextWriter writer, 
-            Scope keyScope, 
+            TextWriter writer,
+            Scope keyScope,
             Dictionary<string, object> arguments,
             Scope contextScope)
         {
@@ -59,17 +59,34 @@ namespace Mustache
                 yield break;
             }
             int index = 0;
-            foreach (object item in enumerable)
+            IEnumerator iter = enumerable.GetEnumerator();
+            using (iter as IDisposable)
             {
-                NestedContext childContext = new NestedContext() 
-                { 
-                    KeyScope = keyScope.CreateChildScope(item), 
-                    Writer = writer, 
-                    ContextScope = contextScope.CreateChildScope(),
-                };
-                childContext.ContextScope.Set("index", index);
-                yield return childContext;
-                ++index;
+                if (iter.MoveNext())
+                {
+                    object item = iter.Current;
+                    object next = null;
+                    bool isDelimited = true;
+
+                    while (isDelimited)
+                    {
+                        isDelimited = iter.MoveNext();
+
+                        NestedContext childContext = new NestedContext()
+                        {
+                            KeyScope = keyScope.CreateChildScope(item),
+                            Writer = writer,
+                            ContextScope = contextScope.CreateChildScope(),
+                        };
+                        childContext.ContextScope.Set("index", index);
+                        childContext.ContextScope.Set("isDelimited", isDelimited);
+                        yield return childContext;
+                        ++index;
+
+                        if(isDelimited)
+                            item = iter.Current;
+                    }
+                }
             }
         }
 
@@ -79,7 +96,7 @@ namespace Mustache
         /// <returns>The name of the tags that are in scope.</returns>
         protected override IEnumerable<string> GetChildTags()
         {
-            return new string[] { "index" };
+            return new string[] { "index", "delimiter" };
         }
 
         /// <summary>

--- a/mustache-sharp/FormatCompiler.cs
+++ b/mustache-sharp/FormatCompiler.cs
@@ -35,6 +35,8 @@ namespace Mustache
             _tagLookup.Add(eachDefinition.Name, eachDefinition);
             IndexTagDefinition indexDefinition = new IndexTagDefinition();
             _tagLookup.Add(indexDefinition.Name, indexDefinition);
+            DelimiterTagDefinition delimiterDefinition = new DelimiterTagDefinition();
+            _tagLookup.Add(delimiterDefinition.Name, delimiterDefinition);
             WithTagDefinition withDefinition = new WithTagDefinition();
             _tagLookup.Add(withDefinition.Name, withDefinition);
             NewlineTagDefinition newlineDefinition = new NewlineTagDefinition();

--- a/mustache-sharp/mustache-sharp.csproj
+++ b/mustache-sharp/mustache-sharp.csproj
@@ -46,6 +46,7 @@
     <Compile Include="ContentTagDefinition.cs" />
     <Compile Include="Context.cs" />
     <Compile Include="ContextParameter.cs" />
+    <Compile Include="DelimiterTagDefinition.cs" />
     <Compile Include="Substitution.cs" />
     <Compile Include="TagFormattedEventArgs.cs" />
     <Compile Include="HtmlFormatCompiler.cs" />


### PR DESCRIPTION
A common requirement is to have a list with a delimiter that is not shown for the final item - i.e. `1, 2, 3` instead of `1, 2, 3,`. This is often accomplished using the `string.Join` method in C#.

With this pull request, content between delimiter tags will only be shown when not on the final item.

The implementation does not introduce any performance changes as I implemented a custom iteration block such that there is no chance for double-enumeration to get the count/length. 

I added two unit tests, and all tests pass.