### PR TITLE
Add unit tests for empty string, null and single curly brace.

### DIFF
--- a/MustacheSharp.Tests/FormatCompilerTester.cs
+++ b/MustacheSharp.Tests/FormatCompilerTester.cs
@@ -1527,6 +1527,51 @@ Odd
             Assert.AreEqual(expected, actual, "The string was not passed to the formatter.");
         }
 
+        [TestMethod]
+        public void TestCompile_EmptyStringProperty() 
+        {
+            FormatCompiler compiler = new FormatCompiler();
+            const string format = @"{{Greeting}} {{Name}}";
+            var data = new 
+            {
+                Greeting = "Hello",
+                Name = ""
+            };
+            Generator generator = compiler.Compile(format);
+            string actual = generator.Render(data);
+            string expected = "Hello ";
+            Assert.AreEqual(expected, actual, "An empty string property should be rendered as an empty string.");
+        }
+
+        [TestMethod]
+        public void TestCompile_NullValueProperty() {
+            FormatCompiler compiler = new FormatCompiler();
+            const string format = @"{{Greeting}} {{Name}}";
+            var data = new 
+            {
+                Greeting = "Hello",
+                Name = (String)null
+            };
+            Generator generator = compiler.Compile(format);
+            string actual = generator.Render(data);
+            string expected = "Hello ";
+            Assert.AreEqual(expected, actual, "An null valued property should be rendered as an empty string.");
+        }
+
+        [TestMethod]
+        public void TestCompile_AllowSingleCurlyBracesInData() {
+            FormatCompiler compiler = new FormatCompiler();
+            const string format = @"See this code: {{Code}}!";
+            var data = new 
+            {
+                Code = "function() { retrurn 'this is evil'; }"
+            };
+            Generator generator = compiler.Compile(format);
+            string actual = generator.Render(data);
+            string expected = "See this code: function() { retrurn 'this is evil'; }!";
+            Assert.AreEqual(expected, actual, "Should not touch single curly braces in data values.");
+        }
+
         #endregion
 
         #region Numbers

--- a/MustacheSharp.Tests/HtmlFormatCompilerTester.cs
+++ b/MustacheSharp.Tests/HtmlFormatCompilerTester.cs
@@ -28,5 +28,28 @@ namespace Mustache.Test
             });
             Assert.AreEqual("<html><body>Hello, John \"The Man\" Standford!!!</body></html>", html);
         }
+
+        [TestMethod]
+        public void ShouldNotTouchValueContainingSingleCurlyBraces() {
+            HtmlFormatCompiler compiler = new HtmlFormatCompiler();
+            var generator = compiler.Compile("<html><head><style>{{Style}}</style></head><body><b>Bold</b> statement!</body></html>");
+            string html = generator.Render(new 
+            {
+                Style = "b { color: red; }"
+            });
+            Assert.AreEqual("<html><head><style>b { color: red; }</style></head><body><b>Bold</b> statement!</body></html>", html);
+        }
+
+        [TestMethod]
+        public void ShouldNotTouchValueContainingSingleCurlyBracesInsideTripleCurlyBraces() {
+            HtmlFormatCompiler compiler = new HtmlFormatCompiler();
+            var generator = compiler.Compile("<html><head><style>{{{Style}}}</style></head><body><b>Bold</b> statement!</body></html>");
+            string html = generator.Render(new 
+            {
+                Style = "b { color: red; }"
+            });
+            Assert.AreEqual("<html><head><style>b { color: red; }</style></head><body><b>Bold</b> statement!</body></html>", html);
+        }
+
     }
 }


### PR DESCRIPTION
As requested in issue #86 I added unit tests for properties containing empty strings, nulls and single curly braces. It might make sense to add them to the general test suite.